### PR TITLE
fix: update repo name for ausplotsR after move

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -110,7 +110,7 @@ RUN source activate r35 \
  && Rscript --no-restore --no-save -e 'install.packages( \
       c("ALA4R", "rgbif") \
     )' \
- && Rscript --no-restore --no-save -e 'library(devtools); devtools::install_github("GregGuerin/ausplotsR", build_vignettes=TRUE)' \
+ && Rscript --no-restore --no-save -e 'library(devtools); devtools::install_github("ternaustralia/ausplotsR", build_vignettes=TRUE)' \
  && Rscript --no-restore --no-save -e 'install.packages(c("googlesheets", "MuMIn", "doBy", "doSNOW", "gamm4"))' \
  && Rscript --no-restore --no-save -e 'library(devtools); devtools::install_github("beckyfisher/FSSgam_package")'
 


### PR DESCRIPTION
We moved the repo to the GitHub org. The old link still works as a redirect, so no rush.